### PR TITLE
[2단계 - 행운의 로또미션] 파노(전환오) 미션 제출합니다

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,114 +1,71 @@
-import React, { Component } from 'react';
+import { createRef, RefObject, useState } from 'react';
 import PaymentForm from './components/PaymentForm/PaymentForm';
 import TicketList from './components/TicketList/TicketList';
 import ResultModal from './components/ResultModal/ResultModal';
 import WinningNumberForm from './components/WinningNumberForm/WinningNumberForm';
 import { AppWrapper } from './App.styles';
 import { issueTickets } from './services/tickets';
-import { getRemainedTime } from './utils/date';
 import RemainedTime from './components/RemainedTime/RemainedTime';
 import { Ticket, WinningNumber } from './types';
 
-type State = {
-  tickets: Ticket[];
-  winningNumber: WinningNumber;
-  isModalOpen: boolean;
-  remainTime: number;
+const App = () => {
+  const [tickets, setTickets] = useState<Ticket[]>([]);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [winningNumber, setWinningNumber] = useState<WinningNumber>({
+    numbers: [],
+    bonus: 0,
+  });
+
+  const winningNumberFormRef: RefObject<HTMLFormElement> = createRef();
+
+  const handlePayment = (payment: number) => {
+    setTickets(issueTickets(payment));
+  };
+
+  const handleWinningNumber = (winningNumber: WinningNumber) => {
+    setWinningNumber(winningNumber);
+    setIsModalOpen(true);
+  };
+
+  const resetStates = () => {
+    setTickets([]);
+    setWinningNumber({
+      numbers: [],
+      bonus: 0,
+    });
+    setIsModalOpen(false);
+  };
+
+  const resetGame = () => {
+    resetStates();
+    winningNumberFormRef.current?.reset();
+  };
+
+  return (
+    <AppWrapper display="flex">
+      <h1 className="app-title">🎱 행운의 로또</h1>
+      <PaymentForm handlePayment={handlePayment} />
+      {!!tickets.length && (
+        <>
+          <TicketList tickets={tickets} />
+          <RemainedTime />
+          <WinningNumberForm
+            handleWinningNumber={handleWinningNumber}
+            formRef={winningNumberFormRef}
+          />
+        </>
+      )}
+
+      {isModalOpen && (
+        <ResultModal
+          handleModalClose={() => setIsModalOpen(false)}
+          resetGame={resetGame}
+          tickets={tickets}
+          winningNumber={winningNumber}
+        />
+      )}
+    </AppWrapper>
+  );
 };
 
-export default class App extends Component<{}, State> {
-  winningNumberFormRef: React.RefObject<HTMLFormElement>;
-  remainTimer: NodeJS.Timeout | null;
-
-  constructor(props: {}) {
-    super(props);
-    this.winningNumberFormRef = React.createRef();
-    this.remainTimer = null;
-
-    this.state = {
-      tickets: [],
-      winningNumber: {
-        numbers: [],
-        bonus: 0,
-      },
-      isModalOpen: false,
-      remainTime: 0,
-    };
-
-    this.handlePayment = this.handlePayment.bind(this);
-    this.handleWinningNumber = this.handleWinningNumber.bind(this);
-    this.handleModal = this.handleModal.bind(this);
-    this.handleRemainedTime = this.handleRemainedTime.bind(this);
-    this.resetGame = this.resetGame.bind(this);
-  }
-
-  handleRemainedTime() {
-    this.setState({
-      remainTime: getRemainedTime(),
-    });
-  }
-
-  handlePayment(payment: number) {
-    const tickets = issueTickets(payment);
-
-    this.setState({ tickets });
-    this.handleRemainedTime();
-    this.remainTimer = setInterval(() => {
-      this.handleRemainedTime();
-    }, 1000);
-  }
-
-  handleWinningNumber(winningNumber: WinningNumber) {
-    this.setState({ winningNumber });
-    this.handleModal(true);
-  }
-
-  handleModal(isOpen: boolean) {
-    this.setState({ isModalOpen: isOpen });
-  }
-
-  resetGame() {
-    this.setState({
-      tickets: [],
-      winningNumber: {
-        numbers: [],
-        bonus: 0,
-      },
-      isModalOpen: false,
-      remainTime: 0,
-    });
-
-    this.winningNumberFormRef.current?.reset();
-    this.remainTimer && clearInterval(this.remainTimer);
-  }
-
-  render() {
-    const { remainTime, tickets, winningNumber, isModalOpen } = this.state;
-
-    return (
-      <AppWrapper display="flex">
-        <h1 className="app-title">🎱 행운의 로또</h1>
-        <PaymentForm handlePayment={this.handlePayment} />
-        {!!tickets.length && (
-          <>
-            <TicketList tickets={tickets} />
-            <RemainedTime remainTime={remainTime} />
-            <WinningNumberForm
-              handleWinningNumber={this.handleWinningNumber}
-              formRef={this.winningNumberFormRef}
-            />
-          </>
-        )}
-
-        {isModalOpen && (
-          <ResultModal
-            handleModalClose={() => this.handleModal(false)}
-            resetGame={this.resetGame}
-            tickets={tickets}
-            winningNumber={winningNumber}
-          />
-        )}
-      </AppWrapper>
-    );
-  }
-}
+export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { AppWrapper } from './App.styles';
 import { issueTickets } from './services/tickets';
 import { getRemainedTime } from './utils/date';
 import RemainedTime from './components/RemainedTime/RemainedTime';
+import { Ticket, WinningNumber } from './types';
 
 type State = {
   tickets: Ticket[];

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { createRef, RefObject, useState } from 'react';
+import { useRef, useState } from 'react';
 import PaymentForm from './components/PaymentForm/PaymentForm';
 import TicketList from './components/TicketList/TicketList';
 import ResultModal from './components/ResultModal/ResultModal';
@@ -16,7 +16,7 @@ const App = () => {
     bonus: 0,
   });
 
-  const winningNumberFormRef: RefObject<HTMLFormElement> = createRef();
+  const winningNumberFormRef = useRef<HTMLFormElement>(null);
 
   const handlePayment = (payment: number) => {
     setTickets(issueTickets(payment));

--- a/src/components/PaymentForm/PaymentForm.tsx
+++ b/src/components/PaymentForm/PaymentForm.tsx
@@ -1,67 +1,51 @@
-import { Component, ChangeEvent, FormEvent } from 'react';
+import { ChangeEvent, FormEvent, FC, useState } from 'react';
 import Button from '../common/Button';
 import Input from '../common/Input';
 import { Wrapper } from '../common/Wrapper';
 import { PaymentFormWrapper, PaymentFormLabel } from './PaymentForm.styles';
-import { alertByPaymentCase, isValidPayment } from '../../services/validation';
+import { isValidPayment } from '../../services/validation';
+import ALERT_MESSAGE from '../../constants/alertMessage';
 
-type Props = {
+interface Props {
   handlePayment: (newPayment: number) => void;
-};
+}
 
-type State = {
-  payment: number;
-};
+const PaymentForm: FC<Props> = ({ handlePayment }) => {
+  const [payment, setPayment] = useState(0);
 
-export default class PaymentForm extends Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
+  const handleInputChange = ({ target }: ChangeEvent<HTMLInputElement>) => {
+    setPayment(target.valueAsNumber);
+  };
 
-    this.state = {
-      payment: 0,
-    };
-
-    this.handleInputChange = this.handleInputChange.bind(this);
-    this.handleSubmit = this.handleSubmit.bind(this);
-  }
-
-  handleInputChange(event: ChangeEvent<HTMLInputElement>) {
-    this.setState({
-      payment: event.target.valueAsNumber,
-    });
-  }
-
-  handleSubmit(event: FormEvent<HTMLFormElement>) {
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    if (isValidPayment(this.state.payment)) {
-      alertByPaymentCase(this.state.payment);
+    if (isValidPayment(payment)) {
+      alert(ALERT_MESSAGE.SHOULD_MORE_THAN_MINIMUM_PAYMENT);
       return;
     }
 
-    this.setState({
-      payment: 0,
-    });
-    this.props.handlePayment(this.state.payment);
-  }
+    setPayment(0);
+    handlePayment(payment);
+  };
 
-  render() {
-    return (
-      <PaymentFormWrapper onSubmit={this.handleSubmit}>
-        <PaymentFormLabel>구입할 금액을 입력해주세요</PaymentFormLabel>
-        <Wrapper display="flex">
-          <Input
-            fullWidth
-            type="number"
-            onChange={this.handleInputChange}
-            value={this.state.payment === 0 ? '' : this.state.payment}
-            placeholder="구입 금액"
-            name="payment-input"
-            required
-          />
-          <Button>확인</Button>
-        </Wrapper>
-      </PaymentFormWrapper>
-    );
-  }
-}
+  return (
+    <PaymentFormWrapper onSubmit={handleSubmit}>
+      <PaymentFormLabel>구입할 금액을 입력해주세요</PaymentFormLabel>
+      <Wrapper display="flex">
+        <Input
+          fullWidth
+          type="number"
+          onChange={handleInputChange}
+          value={payment === 0 ? '' : payment}
+          placeholder="구입 금액"
+          name="payment-input"
+          required
+        />
+        <Button>확인</Button>
+      </Wrapper>
+    </PaymentFormWrapper>
+  );
+};
+
+export default PaymentForm;

--- a/src/components/RemainedTime/RemainedTime.tsx
+++ b/src/components/RemainedTime/RemainedTime.tsx
@@ -3,23 +3,21 @@ import { getDate, getHours, getMinutes, getRemainedTime, getSeconds } from '../.
 import { RemainedTimeWrapper } from './RemainedTime.styles';
 
 const RemainedTime = () => {
-  const [remainTime, setRemainTime] = useState(0);
+  const [remainTime, setRemainTime] = useState(getRemainedTime());
 
-  const date = getDate(remainTime);
-  const hours = getHours(remainTime);
-  const minutes = getMinutes(remainTime);
-  const seconds = getSeconds(remainTime);
+  useEffect(() => {
+    const remainTimerId = setInterval(() => {
+      setRemainTime(getRemainedTime());
+    }, 1000);
 
-  const remainTimerId = setInterval(() => {
-    setRemainTime(getRemainedTime());
-  }, 1000);
-
-  useEffect(() => clearInterval(remainTimerId));
+    return () => clearInterval(remainTimerId);
+  }, []);
 
   return (
     <RemainedTimeWrapper>
       <p className="remain-time-text">
-        당첨발표까지 {date}일 {hours}시 {minutes}분 {seconds}초 남았습니다.
+        당첨발표까지 {getDate(remainTime)}일 {getHours(remainTime)}시 {getMinutes(remainTime)}분{' '}
+        {getSeconds(remainTime)}초 남았습니다.
       </p>
     </RemainedTimeWrapper>
   );

--- a/src/components/RemainedTime/RemainedTime.tsx
+++ b/src/components/RemainedTime/RemainedTime.tsx
@@ -1,26 +1,28 @@
-import { Component } from 'react';
-import { getDate, getHours, getMinutes, getSeconds } from '../../utils/date';
+import { useEffect, useState } from 'react';
+import { getDate, getHours, getMinutes, getRemainedTime, getSeconds } from '../../utils/date';
 import { RemainedTimeWrapper } from './RemainedTime.styles';
 
-type Props = {
-  remainTime: number;
+const RemainedTime = () => {
+  const [remainTime, setRemainTime] = useState(0);
+
+  const date = getDate(remainTime);
+  const hours = getHours(remainTime);
+  const minutes = getMinutes(remainTime);
+  const seconds = getSeconds(remainTime);
+
+  const remainTimerId = setInterval(() => {
+    setRemainTime(getRemainedTime());
+  }, 1000);
+
+  useEffect(() => clearInterval(remainTimerId));
+
+  return (
+    <RemainedTimeWrapper>
+      <p className="remain-time-text">
+        당첨발표까지 {date}일 {hours}시 {minutes}분 {seconds}초 남았습니다.
+      </p>
+    </RemainedTimeWrapper>
+  );
 };
 
-export default class RemainedTime extends Component<Props> {
-  render() {
-    const { remainTime } = this.props;
-
-    const date = getDate(remainTime);
-    const hours = getHours(remainTime);
-    const minutes = getMinutes(remainTime);
-    const seconds = getSeconds(remainTime);
-
-    return (
-      <RemainedTimeWrapper>
-        <p className="remain-time-text">
-          당첨발표까지 {date}일 {hours}시 {minutes}분 {seconds}초 남았습니다.
-        </p>
-      </RemainedTimeWrapper>
-    );
-  }
-}
+export default RemainedTime;

--- a/src/components/ResultModal/ResultModal.tsx
+++ b/src/components/ResultModal/ResultModal.tsx
@@ -7,6 +7,7 @@ import ResultTableRow from './ResultTableRow/ResultTableRow';
 import { getTotalProfit, getWinnerCounts } from '../../services/game';
 import TICKET from '../../constants/ticket';
 import { MATCH, PRIZE, RANK_INDEX } from '../../constants/game';
+import { Ticket, WinningNumber } from '../../types';
 
 type Props = {
   handleModalClose: () => void;

--- a/src/components/ResultModal/ResultModal.tsx
+++ b/src/components/ResultModal/ResultModal.tsx
@@ -1,74 +1,59 @@
-import { Component } from 'react';
+import { FC } from 'react';
 import Modal from '../common/Modal';
 import Button from '../common/Button';
 import { Wrapper } from '../common/Wrapper';
 import { ResultModalWrapper, ResultTable } from './ResultModal.styles';
 import ResultTableRow from './ResultTableRow/ResultTableRow';
-import { getTotalProfit, getWinnerCounts } from '../../services/game';
-import TICKET from '../../constants/ticket';
+import { computeResult } from '../../services/game';
 import { MATCH, PRIZE, RANK_INDEX } from '../../constants/game';
 import { Ticket, WinningNumber } from '../../types';
 
-type Props = {
+interface Props {
   handleModalClose: () => void;
   resetGame: () => void;
   tickets: Ticket[];
   winningNumber: WinningNumber;
+}
+
+const ResultModal: FC<Props> = ({ handleModalClose, resetGame, tickets, winningNumber }) => {
+  const { FIRST, SECOND, THIRD, FOURTH, FIFTH } = RANK_INDEX;
+  const { winnerCounts, profit } = computeResult(tickets, winningNumber);
+
+  return (
+    <Modal handleModalClose={handleModalClose}>
+      <ResultModalWrapper>
+        <h2 className="result-header">🏆 당첨 통계 🏆</h2>
+        <Wrapper display="flex">
+          <ResultTable>
+            <thead>
+              <tr>
+                <th>일치 갯수</th>
+                <th>당첨금</th>
+                <th>당첨 갯수</th>
+              </tr>
+            </thead>
+            <tbody>
+              {[FIFTH, FOURTH, THIRD, SECOND, FIRST].map((rank, index) => (
+                <ResultTableRow
+                  key={index}
+                  match={MATCH[rank]}
+                  prize={PRIZE[rank]}
+                  isBonus={rank === SECOND}
+                  matchCount={winnerCounts[rank]}
+                />
+              ))}
+            </tbody>
+          </ResultTable>
+        </Wrapper>
+        <p className="profit">수익률은 {profit}% 입니다.</p>
+        <Wrapper display="flex">
+          <Button type="reset" fullWidth onClick={resetGame}>
+            다시 시작하기
+          </Button>
+        </Wrapper>
+      </ResultModalWrapper>
+    </Modal>
+  );
 };
 
-export default class ResultModal extends Component<Props> {
-  componentDidMount() {
-    this.computeResult();
-  }
-
-  computeResult() {
-    const { tickets, winningNumber } = this.props;
-    const payment = tickets.length * TICKET.PRICE;
-    const winnerCounts = getWinnerCounts(tickets, winningNumber);
-    const profit = getTotalProfit(payment, winnerCounts);
-
-    return { winnerCounts, profit };
-  }
-
-  render() {
-    const { handleModalClose, resetGame } = this.props;
-    const { winnerCounts, profit } = this.computeResult();
-    const { FIRST, SECOND, THIRD, FOURTH, FIFTH } = RANK_INDEX;
-
-    return (
-      <Modal handleModalClose={handleModalClose}>
-        <ResultModalWrapper>
-          <h2 className="result-header">🏆 당첨 통계 🏆</h2>
-          <Wrapper display="flex">
-            <ResultTable>
-              <thead>
-                <tr>
-                  <th>일치 갯수</th>
-                  <th>당첨금</th>
-                  <th>당첨 갯수</th>
-                </tr>
-              </thead>
-              <tbody>
-                {[FIFTH, FOURTH, THIRD, SECOND, FIRST].map((rank, index) => (
-                  <ResultTableRow
-                    key={index}
-                    match={MATCH[rank]}
-                    prize={PRIZE[rank]}
-                    isBonus={rank === SECOND}
-                    matchCount={winnerCounts[rank]}
-                  />
-                ))}
-              </tbody>
-            </ResultTable>
-          </Wrapper>
-          <p className="profit">수익률은 {profit}% 입니다.</p>
-          <Wrapper display="flex">
-            <Button type="reset" fullWidth onClick={resetGame}>
-              다시 시작하기
-            </Button>
-          </Wrapper>
-        </ResultModalWrapper>
-      </Modal>
-    );
-  }
-}
+export default ResultModal;

--- a/src/components/ResultModal/ResultModal.tsx
+++ b/src/components/ResultModal/ResultModal.tsx
@@ -16,7 +16,6 @@ interface Props {
 }
 
 const ResultModal: FC<Props> = ({ handleModalClose, resetGame, tickets, winningNumber }) => {
-  const { FIRST, SECOND, THIRD, FOURTH, FIFTH } = RANK_INDEX;
   const { winnerCounts, profit } = computeResult(tickets, winningNumber);
 
   return (
@@ -33,13 +32,13 @@ const ResultModal: FC<Props> = ({ handleModalClose, resetGame, tickets, winningN
               </tr>
             </thead>
             <tbody>
-              {[FIFTH, FOURTH, THIRD, SECOND, FIRST].map((rank, index) => (
+              {Object.values(RANK_INDEX).map(index => (
                 <ResultTableRow
                   key={index}
-                  match={MATCH[rank]}
-                  prize={PRIZE[rank]}
-                  isBonus={rank === SECOND}
-                  matchCount={winnerCounts[rank]}
+                  match={MATCH[index]}
+                  prize={PRIZE[index]}
+                  isBonus={index === RANK_INDEX.SECOND}
+                  matchCount={winnerCounts[index]}
                 />
               ))}
             </tbody>

--- a/src/components/ResultModal/ResultTableRow/ResultTableRow.tsx
+++ b/src/components/ResultModal/ResultTableRow/ResultTableRow.tsx
@@ -1,25 +1,23 @@
-import { Component } from 'react';
+import { FC } from 'react';
 import { getKRMoneyString } from '../../../utils/format';
 
-type ResultTableRowProps = {
+interface Props {
   match: number;
   prize: number;
   matchCount: number;
   isBonus?: boolean;
+}
+
+const ResultTableRow: FC<Props> = ({ match, matchCount, prize, isBonus }) => {
+  return (
+    <tr>
+      <td>
+        {match}개 {isBonus && '+ 보너스볼'}
+      </td>
+      <td>{getKRMoneyString(prize)}</td>
+      <td>{matchCount}개</td>
+    </tr>
+  );
 };
 
-export default class ResultTableRow extends Component<ResultTableRowProps> {
-  render() {
-    const { match, isBonus, matchCount, prize } = this.props;
-
-    return (
-      <tr>
-        <td>
-          {match}개 {isBonus && '+ 보너스볼'}
-        </td>
-        <td>{getKRMoneyString(prize)}</td>
-        <td>{matchCount}개</td>
-      </tr>
-    );
-  }
-}
+export default ResultTableRow;

--- a/src/components/TicketList/TicketItem/TicketItem.tsx
+++ b/src/components/TicketList/TicketItem/TicketItem.tsx
@@ -1,20 +1,18 @@
-import React, { Component } from 'react';
+import { FC } from 'react';
 import { TicketItemWrapper } from './TicketItem.styles';
 
-type Props = {
+interface Props {
   ticketNumbers: number[];
   isDetailMode: boolean;
+}
+
+const TicketItem: FC<Props> = ({ ticketNumbers, isDetailMode }) => {
+  return (
+    <TicketItemWrapper>
+      <span className="ticket-icon">🎟️ </span>
+      {isDetailMode && <span className="ticket-number">{ticketNumbers.join(' ')}</span>}
+    </TicketItemWrapper>
+  );
 };
 
-export default class TicketItem extends Component<Props> {
-  render() {
-    const { isDetailMode, ticketNumbers } = this.props;
-
-    return (
-      <TicketItemWrapper>
-        <span className="ticket-icon">🎟️ </span>
-        {isDetailMode && <span className="ticket-number">{ticketNumbers.join(' ')}</span>}
-      </TicketItemWrapper>
-    );
-  }
-}
+export default TicketItem;

--- a/src/components/TicketList/TicketList.tsx
+++ b/src/components/TicketList/TicketList.tsx
@@ -1,48 +1,35 @@
-import React, { Component } from 'react';
+import { FC, useState } from 'react';
 import Toggle from '../common/Toggle';
 import { TicketListHeader, TicketListWrapper, List } from './TicketList.styles';
 import TicketItem from './TicketItem/TicketItem';
 import { Ticket } from '../../types';
 
-type Props = {
+interface Props {
   tickets: Ticket[];
-};
-
-type State = {
-  isToggled: boolean;
-};
-
-export default class TicketList extends Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-
-    this.state = { isToggled: false };
-
-    this.onToggle = this.onToggle.bind(this);
-  }
-
-  onToggle(isToggled: boolean) {
-    this.setState({ isToggled });
-  }
-
-  render() {
-    const { isToggled } = this.state;
-    const { tickets } = this.props;
-
-    return (
-      <TicketListWrapper>
-        <TicketListHeader>
-          <label className="ticket-list-header-label">총 {tickets.length}개를 구매하였습니다</label>
-          <div>
-            <Toggle onToggle={this.onToggle}>번호보기</Toggle>
-          </div>
-        </TicketListHeader>
-        <List isToggled={isToggled}>
-          {tickets.map(ticket => (
-            <TicketItem key={ticket.id} ticketNumbers={ticket.numbers} isDetailMode={isToggled} />
-          ))}
-        </List>
-      </TicketListWrapper>
-    );
-  }
 }
+
+const TicketList: FC<Props> = ({ tickets }) => {
+  const [isToggled, setIsToggled] = useState(false);
+
+  const onToggle = (isToggled: boolean) => {
+    setIsToggled(isToggled);
+  };
+
+  return (
+    <TicketListWrapper>
+      <TicketListHeader>
+        <label className="ticket-list-header-label">총 {tickets.length}개를 구매하였습니다</label>
+        <div>
+          <Toggle onToggle={onToggle}>번호보기</Toggle>
+        </div>
+      </TicketListHeader>
+      <List isToggled={isToggled}>
+        {tickets.map(ticket => (
+          <TicketItem key={ticket.id} ticketNumbers={ticket.numbers} isDetailMode={isToggled} />
+        ))}
+      </List>
+    </TicketListWrapper>
+  );
+};
+
+export default TicketList;

--- a/src/components/TicketList/TicketList.tsx
+++ b/src/components/TicketList/TicketList.tsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import Toggle from '../common/Toggle';
 import { TicketListHeader, TicketListWrapper, List } from './TicketList.styles';
 import TicketItem from './TicketItem/TicketItem';
+import { Ticket } from '../../types';
 
 type Props = {
   tickets: Ticket[];

--- a/src/components/WinningNumberForm/WinningNumberForm.tsx
+++ b/src/components/WinningNumberForm/WinningNumberForm.tsx
@@ -5,6 +5,7 @@ import { Wrapper } from '../common/Wrapper';
 import Button from '../common/Button';
 import { isValidWinningNumber, isWinningNumberDuplicated } from '../../services/validation';
 import ALERT_MESSAGE from '../../constants/alertMessage';
+import { WinningNumber } from '../../types';
 
 type Props = {
   formRef: React.RefObject<HTMLFormElement>;

--- a/src/components/WinningNumberForm/WinningNumberForm.tsx
+++ b/src/components/WinningNumberForm/WinningNumberForm.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import { ChangeEvent, FC, FormEvent, RefObject, useState } from 'react';
 import { WinningNumberFormWrapper } from './WinningNumberForm.styles';
 import Input from '../common/Input';
 import { Wrapper } from '../common/Wrapper';
@@ -7,50 +7,60 @@ import { isValidWinningNumber, isWinningNumberDuplicated } from '../../services/
 import ALERT_MESSAGE from '../../constants/alertMessage';
 import { WinningNumber } from '../../types';
 
-type Props = {
-  formRef: React.RefObject<HTMLFormElement>;
+interface Props {
+  formRef: RefObject<HTMLFormElement>;
   handleWinningNumber: (winningNumber: WinningNumber) => void;
+}
+
+interface SetMap {
+  first: (value: number) => void;
+  second: (value: number) => void;
+  third: (value: number) => void;
+  fourth: (value: number) => void;
+  fifth: (value: number) => void;
+  sixth: (value: number) => void;
+  bonus: (value: number) => void;
+}
+
+const isInSetMap = (name: string, setMap: SetMap): name is keyof SetMap => {
+  return Object.keys(setMap).includes(name);
 };
 
-type State = {
-  [key: string]: number;
-};
+const WinningNumberForm: FC<Props> = ({ formRef, handleWinningNumber }) => {
+  const [first, setFirst] = useState(0);
+  const [second, setSecond] = useState(0);
+  const [third, setThird] = useState(0);
+  const [fourth, setFourth] = useState(0);
+  const [fifth, setFifth] = useState(0);
+  const [sixth, setSixth] = useState(0);
+  const [bonus, setBonus] = useState(0);
 
-export default class WinningNumberForm extends Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
+  const setMap: SetMap = {
+    first: (value: number) => setFirst(value),
+    second: (value: number) => setSecond(value),
+    third: (value: number) => setThird(value),
+    fourth: (value: number) => setFourth(value),
+    fifth: (value: number) => setFifth(value),
+    sixth: (value: number) => setSixth(value),
+    bonus: (value: number) => setBonus(value),
+  };
 
-    this.state = {
-      first: 0,
-      second: 0,
-      third: 0,
-      fourth: 0,
-      fifth: 0,
-      sixth: 0,
-      bonus: 0,
-    };
-
-    this.handleWinningNumberInputChange = this.handleWinningNumberInputChange.bind(this);
-    this.handleSubmit = this.handleSubmit.bind(this);
-  }
-
-  handleWinningNumberInputChange(event: React.ChangeEvent<HTMLInputElement>) {
+  const handleWinningNumberInputChange = (event: ChangeEvent<HTMLInputElement>) => {
     const { name, valueAsNumber: value } = event.target;
 
     if (!isValidWinningNumber(value)) {
       alert(ALERT_MESSAGE.NUMBER_RANGE_EXCEEDED);
       event.target.value = '';
-      this.setState({ [name]: 0 });
+      if (isInSetMap(name, setMap)) setMap[name](0);
       return;
     }
 
-    this.setState({ [name]: value });
-  }
+    if (isInSetMap(name, setMap)) setMap[name](value);
+  };
 
-  handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    const { first, second, third, fourth, fifth, sixth, bonus } = this.state;
     const winningNumber = {
       numbers: [first, second, third, fourth, fifth, sixth],
       bonus,
@@ -61,34 +71,31 @@ export default class WinningNumberForm extends Component<Props, State> {
       return;
     }
 
-    this.props.handleWinningNumber(winningNumber);
-  }
+    handleWinningNumber(winningNumber);
+  };
 
-  render() {
-    return (
-      <WinningNumberFormWrapper onSubmit={this.handleSubmit} ref={this.props.formRef}>
-        <label className="input-label">당첨번호 6개와 보너스 넘버 1개를 입력해주세요.</label>
-        <Wrapper className="winning-number-input-wrapper" display="flex">
-          <div>
-            <h4 className="input-caption">당첨 번호</h4>
-            <Wrapper display="flex" onChange={this.handleWinningNumberInputChange}>
-              <Input type="number" name="first" required />
-              <Input type="number" name="second" required />
-              <Input type="number" name="third" required />
-              <Input type="number" name="fourth" required />
-              <Input type="number" name="fifth" required />
-              <Input type="number" name="sixth" required />
-            </Wrapper>
-          </div>
-          <div>
-            <h4 className="input-caption">보너스 번호</h4>
-            <Wrapper display="flex" onChange={this.handleWinningNumberInputChange}>
-              <Input type="number" name="bonus" required />
-            </Wrapper>
-          </div>
-        </Wrapper>
-        <Button fullWidth>결과 확인하기</Button>
-      </WinningNumberFormWrapper>
-    );
-  }
-}
+  return (
+    <WinningNumberFormWrapper onSubmit={handleSubmit} ref={formRef}>
+      <label className="input-label">당첨번호 6개와 보너스 넘버 1개를 입력해주세요.</label>
+      <Wrapper className="winning-number-input-wrapper" display="flex">
+        <div>
+          <h4 className="input-caption">당첨 번호</h4>
+          <Wrapper display="flex" onChange={handleWinningNumberInputChange}>
+            {['first', 'second', 'third', 'fourth', 'fifth', 'sixth'].map((el, idx) => (
+              <Input key={idx} type="number" name={el} required />
+            ))}
+          </Wrapper>
+        </div>
+        <div>
+          <h4 className="input-caption">보너스 번호</h4>
+          <Wrapper display="flex" onChange={handleWinningNumberInputChange}>
+            <Input type="number" name="bonus" required />
+          </Wrapper>
+        </div>
+      </Wrapper>
+      <Button fullWidth>결과 확인하기</Button>
+    </WinningNumberFormWrapper>
+  );
+};
+
+export default WinningNumberForm;

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,10 +1,10 @@
 import styled from 'styled-components';
 
-type ButtonProps = {
+interface Props {
   fullWidth?: boolean;
-};
+}
 
-const Button = styled.button<ButtonProps>`
+const Button = styled.button<Props>`
   background-color: #00bcd4;
   height: 36px;
   min-width: 64px;

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -1,10 +1,10 @@
 import styled from 'styled-components';
 
-type InputProps = {
+interface Props {
   fullWidth?: boolean;
-};
+}
 
-const Input = styled.input<InputProps>`
+const Input = styled.input<Props>`
   padding: 0.5rem;
   margin: 0 0.25rem;
 

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import { FC } from 'react';
 import styled from 'styled-components';
 
 const ModalWrapper = styled.div`
@@ -44,23 +44,23 @@ const ModalClose = styled.div`
   }
 `;
 
-type ModalProps = {
+interface Props {
   handleModalClose: () => void;
+}
+
+const Modal: FC<Props> = ({ handleModalClose, children }) => {
+  return (
+    <ModalWrapper>
+      <ModalInner>
+        <ModalClose onClick={handleModalClose}>
+          <svg viewBox="0 0 40 40">
+            <path className="close-x" d="M 10,10 L 30,30 M 30,10 L 10,30" />
+          </svg>
+        </ModalClose>
+        {children}
+      </ModalInner>
+    </ModalWrapper>
+  );
 };
 
-export default class Modal extends Component<ModalProps> {
-  render() {
-    return (
-      <ModalWrapper>
-        <ModalInner>
-          <ModalClose onClick={this.props.handleModalClose}>
-            <svg viewBox="0 0 40 40">
-              <path className="close-x" d="M 10,10 L 30,30 M 30,10 L 10,30" />
-            </svg>
-          </ModalClose>
-          {this.props.children}
-        </ModalInner>
-      </ModalWrapper>
-    );
-  }
-}
+export default Modal;

--- a/src/components/common/Toggle.tsx
+++ b/src/components/common/Toggle.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { ChangeEvent, FC } from 'react';
 import styled from 'styled-components';
 
 const ToggleWrapper = styled.label`
@@ -119,28 +119,21 @@ const ToggleWrapper = styled.label`
     background-color: rgba(0, 188, 212, 0.6);
   }
 `;
-
-type Props = {
+interface Props {
   onToggle: (isToggled: boolean) => void;
+}
+
+const Toggle: FC<Props> = ({ onToggle, children }) => {
+  const handleToggle = (event: ChangeEvent<HTMLInputElement>) => {
+    onToggle(event.target.checked);
+  };
+
+  return (
+    <ToggleWrapper>
+      <input onChange={handleToggle} type="checkbox" className="toggle-button" />
+      <span className="toggle-text">{children}</span>
+    </ToggleWrapper>
+  );
 };
 
-export default class Toggle extends Component<Props> {
-  constructor(props: Props) {
-    super(props);
-
-    this.handleToggle = this.handleToggle.bind(this);
-  }
-
-  handleToggle(event: React.ChangeEvent<HTMLInputElement>) {
-    this.props.onToggle(event.target.checked);
-  }
-
-  render() {
-    return (
-      <ToggleWrapper>
-        <input onChange={this.handleToggle} type="checkbox" className="toggle-button" />
-        <span className="toggle-text">{this.props.children}</span>
-      </ToggleWrapper>
-    );
-  }
-}
+export default Toggle;

--- a/src/components/common/Wrapper.tsx
+++ b/src/components/common/Wrapper.tsx
@@ -1,15 +1,15 @@
 import styled, { css } from 'styled-components';
 
-type WrapperProps = {
+interface Props {
   display?: 'block' | 'flex' | 'inline-block';
-};
+}
 
 const flexCenter = css`
   justify-content: center;
   align-items: center;
 `;
 
-export const Wrapper = styled.div<WrapperProps>`
+export const Wrapper = styled.div<Props>`
   display: ${({ display }) => display || 'block'};
   ${({ display }) => display === 'flex' && flexCenter}
 `;

--- a/src/constants/game.ts
+++ b/src/constants/game.ts
@@ -1,9 +1,9 @@
 export const RANK_INDEX = {
-  FIRST: 0,
-  SECOND: 1,
-  THIRD: 2,
-  FOURTH: 3,
   FIFTH: 4,
+  FOURTH: 3,
+  THIRD: 2,
+  SECOND: 1,
+  FIRST: 0,
 };
 
 export const PRIZE = {

--- a/src/services/game.ts
+++ b/src/services/game.ts
@@ -1,4 +1,5 @@
 import { RANK_INDEX, PRIZE } from '../constants/game';
+import { Ticket, WinningNumber } from '../types';
 
 const hasBonus = (ticketNumbers: number[], bonus: number) => {
   return ticketNumbers.includes(bonus);

--- a/src/services/game.ts
+++ b/src/services/game.ts
@@ -1,4 +1,5 @@
 import { RANK_INDEX, PRIZE } from '../constants/game';
+import TICKET from '../constants/ticket';
 import { Ticket, WinningNumber } from '../types';
 
 const hasBonus = (ticketNumbers: number[], bonus: number) => {
@@ -53,4 +54,12 @@ export const getTotalProfit = (payment: number, winnerCounts: number[]) => {
   );
 
   return ((income - payment) / payment) * 100;
+};
+
+export const computeResult = (tickets: Ticket[], winningNumber: WinningNumber) => {
+  const payment = tickets.length * TICKET.PRICE;
+  const winnerCounts = getWinnerCounts(tickets, winningNumber);
+  const profit = getTotalProfit(payment, winnerCounts);
+
+  return { winnerCounts, profit };
 };

--- a/src/services/tickets.ts
+++ b/src/services/tickets.ts
@@ -1,5 +1,6 @@
 import { nanoid } from 'nanoid';
 import TICKET from '../constants/ticket';
+import { Ticket } from '../types';
 import { getRandomNumber } from '../utils/random';
 
 const generateTicket = (): Ticket => {

--- a/src/services/validation.ts
+++ b/src/services/validation.ts
@@ -1,4 +1,3 @@
-import ALERT_MESSAGE from '../constants/alertMessage';
 import TICKET from '../constants/ticket';
 import { WinningNumber } from '../types';
 import { hasDuplicateElement } from '../utils/validation';

--- a/src/services/validation.ts
+++ b/src/services/validation.ts
@@ -1,22 +1,14 @@
 import ALERT_MESSAGE from '../constants/alertMessage';
 import TICKET from '../constants/ticket';
+import { WinningNumber } from '../types';
 import { hasDuplicateElement } from '../utils/validation';
 
 export const isValidPayment = (payment: number) => payment < TICKET.PRICE;
 
-export const alertByPaymentCase = (payment: number) => {
-  if (payment < TICKET.PRICE) {
-    alert(ALERT_MESSAGE.SHOULD_MORE_THAN_MINIMUM_PAYMENT);
-  }
-};
-
-export const isValidWinningNumber = (winningNumber: number): boolean => {
+export const isValidWinningNumber = (winningNumber: number) => {
   return winningNumber >= TICKET.MIN_NUMBER && winningNumber <= TICKET.MAX_NUMBER;
 };
 
-export const isWinningNumberDuplicated = ({ numbers, bonus }: WinningNumber): boolean => {
+export const isWinningNumberDuplicated = ({ numbers, bonus }: WinningNumber) => {
   return hasDuplicateElement<number>([...numbers, bonus]);
 };
-
-//TODO: answer Submit에서 alert 한번, 이후 handlewinndingNumber에서 alert 또 한번이 과연 맞는건가?
-// 역할로써는 분리가 맞는데, 두번의 alert는 좀...

--- a/src/type.d.ts
+++ b/src/type.d.ts
@@ -1,9 +1,0 @@
-declare type Ticket = {
-  id: string;
-  numbers: number[];
-};
-
-declare type WinningNumber = {
-  numbers: number[];
-  bonus: number;
-};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,9 @@
+export type Ticket = {
+  id: string;
+  numbers: number[];
+};
+
+export type WinningNumber = {
+  numbers: number[];
+  bonus: number;
+};

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,5 +1,2 @@
-export const getKRMoneyString = (number: number) => {
-  if (Number.isNaN(number)) throw new Error('invalid parameter: NaN');
-
-  return number.toLocaleString('ko-KR');
-};
+export const getKRMoneyString = (number: number) =>
+  Number.isNaN(number) ? '' : number.toLocaleString('ko-KR');


### PR DESCRIPTION
안녕하세요!

2단계 마쳐서 PR 올립니다.
함수컴포넌트로 변경 완료했습니다.

다른 팀원들의 피드백 사항 반영했습니다.

remainedTime 컴포넌트가 props를 받아 렌더링하는 대신 상태로 갖고 렌더링하도록 변경하였습니다.
ResultModal의 computeResult는 service/game.ts파일로 이동했습니다.

클래스에서 함수로 바꾸면서 느낀 점은
1. 클래스여서 필요했던 코드들 (this, bind, constructor, render 등등)을 제거할 수 있어  코드가 전반적으로 깔끔해졌습니다.
2. 코드가 깔끔해짐에 따라 리팩토링할 수 있는 지점이 명확하게 보였던 것 같습니다. 
3. ~~클래스 컴포넌트에서 가능했던 State에 대한 타입체크는 불가능해졌습니다.~~ (틀린 의견입니다 ㅠ)

![image](https://user-images.githubusercontent.com/44419181/115890638-1c2eb100-a490-11eb-9e86-18648c8eac54.png)

이전 피드백에서 NaN을 인자로 받을 때 빈문자열로 리턴하는 의견을 주셨는데, 저도 문제가 없을 것으로 판단하고 반영하였습니다.

## 웹 VSCode 환경
https://github.surf/jho2301/react-lotto/tree/step2

## 데모
https://jho2301.github.io/react-lotto/

감사합니다!